### PR TITLE
Add support for all GPX point types and show import confirmation dialog

### DIFF
--- a/app/src/main/java/no/synth/where/WhereApp.kt
+++ b/app/src/main/java/no/synth/where/WhereApp.kt
@@ -17,7 +17,7 @@ import no.synth.where.data.SavedPoint
 import no.synth.where.navigation.*
 import no.synth.where.service.LocationTrackingService
 import no.synth.where.ui.*
-import no.synth.where.util.Logger
+
 
 @Composable
 fun WhereApp(
@@ -92,19 +92,7 @@ fun WhereApp(
 
     LaunchedEffect(pendingGpxUri) {
         pendingGpxUri?.let { uri ->
-            try {
-                val bytes = context.contentResolver.openInputStream(uri)?.use {
-                    it.readBytes()
-                }
-                if (bytes != null) {
-                    val importedTrack = trackRepository.importTrackFromBytes(bytes)
-                    if (importedTrack != null) {
-                        trackRepository.setViewingTrack(importedTrack)
-                    }
-                }
-            } catch (e: Exception) {
-                Logger.e(e, "Track import error")
-            }
+            navController.navigate(TracksRoute(importFileUri = uri.toString()))
             onGpxHandled()
         }
     }
@@ -160,6 +148,7 @@ fun WhereApp(
             val route = backStackEntry.toRoute<TracksRoute>()
             TracksScreen(
                 pendingImportUrl = route.importUrl,
+                pendingImportFileUri = route.importFileUri,
                 onBackClick = { navController.popBackStack() },
                 onContinueTrack = { track ->
                     trackRepository.continueTrack(track)

--- a/app/src/main/java/no/synth/where/navigation/Routes.kt
+++ b/app/src/main/java/no/synth/where/navigation/Routes.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.Serializable
 
 @Serializable object MapRoute
 @Serializable data class SettingsRoute(val highlightOfflineMode: Boolean = false)
-@Serializable data class TracksRoute(val importUrl: String? = null)
+@Serializable data class TracksRoute(val importUrl: String? = null, val importFileUri: String? = null)
 @Serializable object SavedPointsRoute
 @Serializable object OnlineTrackingRoute
 @Serializable object DownloadRoute

--- a/app/src/main/java/no/synth/where/ui/TracksScreen.kt
+++ b/app/src/main/java/no/synth/where/ui/TracksScreen.kt
@@ -22,6 +22,7 @@ import java.io.File
 @Composable
 fun TracksScreen(
     pendingImportUrl: String? = null,
+    pendingImportFileUri: String? = null,
     onBackClick: () -> Unit,
     onContinueTrack: (Track) -> Unit,
     onShowTrackOnMap: (Track) -> Unit
@@ -40,6 +41,7 @@ fun TracksScreen(
     var importErrorMessage by remember { mutableStateOf("") }
 
     var urlToConfirm by remember { mutableStateOf<String?>(null) }
+    var fileUriToConfirm by remember { mutableStateOf<String?>(null) }
 
     // Pre-resolve strings for use in non-composable lambdas
     val importUrlErrorStr = stringResource(Res.string.import_url_error)
@@ -53,6 +55,10 @@ fun TracksScreen(
 
     LaunchedEffect(pendingImportUrl) {
         if (pendingImportUrl != null) urlToConfirm = pendingImportUrl
+    }
+
+    LaunchedEffect(pendingImportFileUri) {
+        if (pendingImportFileUri != null) fileUriToConfirm = pendingImportFileUri
     }
 
     urlToConfirm?.let { url ->
@@ -73,6 +79,44 @@ fun TracksScreen(
             },
             dismissButton = {
                 TextButton(onClick = { urlToConfirm = null }) {
+                    Text(stringResource(Res.string.cancel))
+                }
+            }
+        )
+    }
+
+    fileUriToConfirm?.let { uriString ->
+        val fileName = Uri.parse(uriString).lastPathSegment ?: uriString
+        AlertDialog(
+            onDismissRequest = { fileUriToConfirm = null },
+            title = { Text(stringResource(Res.string.import_from_title)) },
+            text = { Text(stringResource(Res.string.import_file_message, fileName)) },
+            confirmButton = {
+                TextButton(onClick = {
+                    val uri = Uri.parse(uriString)
+                    fileUriToConfirm = null
+                    try {
+                        val bytes = context.contentResolver.openInputStream(uri)?.use { stream ->
+                            stream.readBytes()
+                        }
+                        if (bytes != null) {
+                            val importedTrack = viewModel.importTrackFromBytes(bytes)
+                            if (importedTrack == null) {
+                                importErrorMessage = importGpxCorruptedStr
+                                showImportError = true
+                            }
+                        } else {
+                            importErrorMessage = importGpxReadFailedStr
+                            showImportError = true
+                        }
+                    } catch (e: Exception) {
+                        importErrorMessage = String.format(importGpxErrorFmt, e.message)
+                        showImportError = true
+                    }
+                }) { Text(stringResource(Res.string.import_label)) }
+            },
+            dismissButton = {
+                TextButton(onClick = { fileUriToConfirm = null }) {
                     Text(stringResource(Res.string.cancel))
                 }
             }

--- a/app/src/test/java/no/synth/where/data/TrackTest.kt
+++ b/app/src/test/java/no/synth/where/data/TrackTest.kt
@@ -236,4 +236,209 @@ class TrackTest {
         )
         assertEquals(60000L, track.getDurationMillis())
     }
+
+    @Test
+    fun fromGPX_parsesWaypoints() {
+        val gpx = """<?xml version="1.0"?>
+            <gpx version="1.1">
+            <wpt lat="59.9139" lon="10.7522"><ele>50.0</ele><time>2025-01-01T12:00:00Z</time></wpt>
+            <wpt lat="60.3913" lon="5.3221"><time>2025-01-01T13:00:00Z</time></wpt>
+            </gpx>"""
+
+        val track = requireNotNull(Track.fromGPX(gpx))
+        assertEquals(2, track.points.size)
+        assertEquals(59.9139, track.points[0].latLng.latitude, 0.0001)
+        assertEquals(50.0, requireNotNull(track.points[0].altitude), 0.01)
+    }
+
+    @Test
+    fun fromGPX_parsesRoutePoints() {
+        val gpx = """<?xml version="1.0"?>
+            <gpx version="1.1">
+            <rte><name>My Route</name>
+            <rtept lat="59.9139" lon="10.7522"><time>2025-01-01T12:00:00Z</time></rtept>
+            <rtept lat="60.3913" lon="5.3221"><time>2025-01-01T13:00:00Z</time></rtept>
+            </rte></gpx>"""
+
+        val track = requireNotNull(Track.fromGPX(gpx))
+        assertEquals("My Route", track.name)
+        assertEquals(2, track.points.size)
+        assertEquals(60.3913, track.points[1].latLng.latitude, 0.0001)
+    }
+
+    @Test
+    fun fromGPX_parsesSelfClosingPoints() {
+        val gpx = """<?xml version="1.0"?>
+            <gpx version="1.1">
+            <wpt lat="59.9139" lon="10.7522"/>
+            <wpt lat="60.3913" lon="5.3221" />
+            </gpx>"""
+
+        val track = requireNotNull(Track.fromGPX(gpx))
+        assertEquals(2, track.points.size)
+        assertEquals(59.9139, track.points[0].latLng.latitude, 0.0001)
+        assertEquals(60.3913, track.points[1].latLng.latitude, 0.0001)
+    }
+
+    @Test
+    fun fromGPX_prefersTrkptOverOtherTypes() {
+        val gpx = """<?xml version="1.0"?>
+            <gpx version="1.1">
+            <wpt lat="59.0" lon="10.0"><time>2025-01-01T12:00:00Z</time></wpt>
+            <trk><trkseg>
+            <trkpt lat="60.0" lon="11.0"><time>2025-01-01T13:00:00Z</time></trkpt>
+            </trkseg></trk>
+            <rte><rtept lat="61.0" lon="12.0"><time>2025-01-01T14:00:00Z</time></rtept></rte>
+            </gpx>"""
+
+        val track = requireNotNull(Track.fromGPX(gpx))
+        assertEquals(1, track.points.size)
+        assertEquals(60.0, track.points[0].latLng.latitude, 0.0001)
+    }
+
+    @Test
+    fun fromGPX_fallsBackToRteptWhenNoTrkpt() {
+        val gpx = """<?xml version="1.0"?>
+            <gpx version="1.1">
+            <wpt lat="59.0" lon="10.0"><time>2025-01-01T12:00:00Z</time></wpt>
+            <rte><rtept lat="61.0" lon="12.0"><time>2025-01-01T14:00:00Z</time></rtept></rte>
+            </gpx>"""
+
+        val track = requireNotNull(Track.fromGPX(gpx))
+        assertEquals(1, track.points.size)
+        assertEquals(61.0, track.points[0].latLng.latitude, 0.0001)
+    }
+
+    @Test
+    fun fromGPX_parsesMultipleTrackSegments() {
+        val gpx = """<?xml version="1.0"?>
+            <gpx version="1.1"><trk><name>Multi Seg</name>
+            <trkseg>
+            <trkpt lat="59.0" lon="10.0"><time>2025-01-01T12:00:00Z</time></trkpt>
+            </trkseg>
+            <trkseg>
+            <trkpt lat="60.0" lon="11.0"><time>2025-01-01T13:00:00Z</time></trkpt>
+            </trkseg>
+            </trk></gpx>"""
+
+        val track = requireNotNull(Track.fromGPX(gpx))
+        assertEquals(2, track.points.size)
+    }
+
+    @Test
+    fun fromGPX_handlesPointsWithNoTime() {
+        val gpx = """<?xml version="1.0"?>
+            <gpx version="1.1">
+            <wpt lat="59.9" lon="10.7"><name>Campsite</name></wpt>
+            </gpx>"""
+
+        val track = requireNotNull(Track.fromGPX(gpx))
+        assertEquals(1, track.points.size)
+        assertEquals(59.9, track.points[0].latLng.latitude, 0.0001)
+    }
+
+    @Test
+    fun fromGPX_prefersMetadataName() {
+        val gpx = """<?xml version="1.0"?>
+            <gpx version="1.1">
+            <metadata><name>My Activity</name></metadata>
+            <trk><name>Track 1</name><trkseg>
+            <trkpt lat="59.9" lon="10.7"><time>2025-01-01T12:00:00Z</time></trkpt>
+            </trkseg></trk></gpx>"""
+
+        val track = requireNotNull(Track.fromGPX(gpx))
+        assertEquals("My Activity", track.name)
+    }
+
+    @Test
+    fun fromGPX_prefersTrackNameOverWaypointName() {
+        val gpx = """<?xml version="1.0"?>
+            <gpx version="1.1">
+            <wpt lat="59.0" lon="10.0"><name>Campsite</name></wpt>
+            <trk><name>Day Hike</name><trkseg>
+            <trkpt lat="59.9" lon="10.7"><time>2025-01-01T12:00:00Z</time></trkpt>
+            </trkseg></trk></gpx>"""
+
+        val track = requireNotNull(Track.fromGPX(gpx))
+        assertEquals("Day Hike", track.name)
+    }
+
+    @Test
+    fun fromGPX_decodesXmlEntitiesInName() {
+        val gpx = """<?xml version="1.0"?>
+            <gpx version="1.1"><trk><name>Hike &amp; Bike &lt;3</name><trkseg>
+            <trkpt lat="59.9" lon="10.7"><time>2025-01-01T12:00:00Z</time></trkpt>
+            </trkseg></trk></gpx>"""
+
+        val track = requireNotNull(Track.fromGPX(gpx))
+        assertEquals("Hike & Bike <3", track.name)
+    }
+
+    @Test
+    fun toGPX_escapesXmlInName() {
+        val track = Track(
+            name = "Run < 5k & fast",
+            points = listOf(
+                TrackPoint(latLng = LatLng(59.9, 10.7), timestamp = 1000L)
+            ),
+            startTime = 1000L
+        )
+        val gpx = track.toGPX()
+        assertTrue(gpx.contains("<name>Run &lt; 5k &amp; fast</name>"))
+    }
+
+    @Test
+    fun toGPX_fromGPX_roundTrip_withSpecialCharsInName() {
+        val original = Track(
+            name = "Tom & Jerry's <Run>",
+            points = listOf(
+                TrackPoint(latLng = LatLng(59.9, 10.7), timestamp = 1704110400000L)
+            ),
+            startTime = 1704110400000L,
+            endTime = 1704110400000L
+        )
+
+        val gpx = original.toGPX()
+        val parsed = requireNotNull(Track.fromGPX(gpx))
+        assertEquals(original.name, parsed.name)
+    }
+
+    @Test
+    fun fromGPX_skipsInvalidCoordinates() {
+        val gpx = """<?xml version="1.0"?>
+            <gpx version="1.1"><trk><trkseg>
+            <trkpt lat="999" lon="10.7"><time>2025-01-01T12:00:00Z</time></trkpt>
+            <trkpt lat="59.9" lon="10.7"><time>2025-01-01T12:01:00Z</time></trkpt>
+            </trkseg></trk></gpx>"""
+
+        val track = requireNotNull(Track.fromGPX(gpx))
+        assertEquals(1, track.points.size)
+        assertEquals(59.9, track.points[0].latLng.latitude, 0.0001)
+    }
+
+    @Test
+    fun fromGPX_timelessPointsGetEarliestRealTimestamp() {
+        val gpx = """<?xml version="1.0"?>
+            <gpx version="1.1"><trk><trkseg>
+            <trkpt lat="59.9" lon="10.7"><time>2025-01-01T12:00:00Z</time></trkpt>
+            <trkpt lat="60.0" lon="11.0"/>
+            </trkseg></trk></gpx>"""
+
+        val track = requireNotNull(Track.fromGPX(gpx))
+        assertEquals(2, track.points.size)
+        assertEquals(1735732800000L, track.points[0].timestamp)
+        assertEquals(1735732800000L, track.points[1].timestamp)
+    }
+
+    @Test
+    fun fromGPX_handlesSingleQuotedAttributes() {
+        val gpx = """<?xml version="1.0"?>
+            <gpx version="1.1"><trk><trkseg>
+            <trkpt lat='59.9' lon='10.7'><time>2025-01-01T12:00:00Z</time></trkpt>
+            </trkseg></trk></gpx>"""
+
+        val track = requireNotNull(Track.fromGPX(gpx))
+        assertEquals(1, track.points.size)
+        assertEquals(59.9, track.points[0].latLng.latitude, 0.0001)
+    }
 }

--- a/shared/src/commonMain/composeResources/values-nb/strings.xml
+++ b/shared/src/commonMain/composeResources/values-nb/strings.xml
@@ -133,6 +133,7 @@
     <string name="import_url_error">Kunne ikke importere fra URL. Aktiviteten eller ruten kan være privat, eller URLen gjenkjennes ikke.</string>
     <string name="import_from_title">Importer spor?</string>
     <string name="import_from_message">Importer spor fra %1$s?</string>
+    <string name="import_file_message">Importer spor fra filen %1$s?</string>
     <string name="import_gpx_corrupted">Kunne ikke importere fil. Filen kan være skadet eller i et format som ikke støttes.</string>
     <string name="import_gpx_read_failed">Kunne ikke lese fil.</string>
     <string name="import_gpx_error">Feil ved import av fil: %1$s</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -137,6 +137,7 @@
     <string name="import_url_error">Could not import from URL. The activity or route may be private, or the URL is not recognized.</string>
     <string name="import_from_title">Import Track?</string>
     <string name="import_from_message">Import track from %1$s?</string>
+    <string name="import_file_message">Import track from file %1$s?</string>
     <string name="import_gpx_corrupted">Failed to import file. The file may be corrupted or in an unsupported format.</string>
     <string name="import_gpx_read_failed">Failed to read file.</string>
     <string name="import_gpx_error">Error importing file: %1$s</string>

--- a/shared/src/commonMain/kotlin/no/synth/where/data/Track.kt
+++ b/shared/src/commonMain/kotlin/no/synth/where/data/Track.kt
@@ -28,6 +28,7 @@ data class Track @OptIn(ExperimentalUuidApi::class) constructor(
     val isRecording: Boolean = false
 ) {
     fun toGPX(): String {
+        val escapedName = name.escapeXml()
         val trackPointsXml = points.joinToString("\n") { point ->
             val timestamp = Instant.fromEpochMilliseconds(point.timestamp).toString()
             val elevation = point.altitude?.let { "\n        <ele>$it</ele>" } ?: ""
@@ -42,11 +43,11 @@ data class Track @OptIn(ExperimentalUuidApi::class) constructor(
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd">
   <metadata>
-    <name>$name</name>
+    <name>$escapedName</name>
     <time>${Instant.fromEpochMilliseconds(startTime)}</time>
   </metadata>
   <trk>
-    <name>$name</name>
+    <name>$escapedName</name>
     <trkseg>
 $trackPointsXml
     </trkseg>
@@ -86,54 +87,113 @@ $trackPointsXml
                 fromFIT(data)
             } else {
                 val text = try { data.decodeToString() } catch (_: Exception) { return null }
-                if (!text.contains("<trkpt", ignoreCase = true)) return null
+                if (!text.contains("<gpx", ignoreCase = true)) return null
                 fromGPX(text)
             }
         }
 
+        // Ordered by priority: prefer tracks over routes over waypoints
+        private val pointTagNames = listOf("trkpt", "rtept", "wpt")
+
+        private fun parsePointsFromTag(gpxContent: String, lower: String, tagName: String, points: MutableList<TrackPoint>) {
+            val tagLower = tagName.lowercase()
+            var searchFrom = 0
+            while (true) {
+                val start = lower.indexOf("<$tagLower ", searchFrom)
+                if (start < 0) break
+
+                val closingTag = lower.indexOf("</$tagLower>", start)
+                val selfClosing = lower.indexOf("/>", start)
+                val nextOpen = lower.indexOf("<", start + 1)
+
+                val (tag, nextSearchFrom) = when {
+                    selfClosing >= 0 && (closingTag < 0 || selfClosing < closingTag) &&
+                        (nextOpen < 0 || selfClosing <= nextOpen) -> {
+                        gpxContent.substring(start, selfClosing + 2) to selfClosing + 2
+                    }
+                    closingTag >= 0 -> {
+                        gpxContent.substring(start, closingTag) to closingTag + tagName.length + 3
+                    }
+                    else -> break
+                }
+
+                searchFrom = nextSearchFrom
+                val tagLc = tag.lowercase()
+
+                val lat = tagLc.substringAfter("lat=\"", "").substringBefore("\"", "").toDoubleOrNull()
+                    ?: tagLc.substringAfter("lat='", "").substringBefore("'", "").toDoubleOrNull()
+                    ?: continue
+                val lon = tagLc.substringAfter("lon=\"", "").substringBefore("\"", "").toDoubleOrNull()
+                    ?: tagLc.substringAfter("lon='", "").substringBefore("'", "").toDoubleOrNull()
+                    ?: continue
+
+                if (lat < -90 || lat > 90 || lon < -180 || lon > 180) continue
+
+                val ele = tagLc.substringAfter("<ele>", "").substringBefore("</ele>", "").toDoubleOrNull()
+                // Extract time from original-case tag — Instant.parse requires uppercase T and Z
+                val timeStart = tagLc.indexOf("<time>")
+                val timeEnd = tagLc.indexOf("</time>")
+                val timeStr = if (timeStart >= 0 && timeEnd > timeStart) tag.substring(timeStart + 6, timeEnd) else ""
+                val timestamp = try {
+                    Instant.parse(timeStr).toEpochMilliseconds()
+                } catch (_: Exception) {
+                    0L
+                }
+
+                points.add(
+                    TrackPoint(
+                        latLng = LatLng(lat, lon),
+                        timestamp = timestamp,
+                        altitude = ele,
+                        accuracy = null
+                    )
+                )
+            }
+        }
+
+        private fun extractName(gpxContent: String): String {
+            val lower = gpxContent.lowercase()
+            // Try metadata name first, then trk name, then rte name, then first name
+            for (parent in listOf("<metadata>", "<trk>", "<rte>")) {
+                val parentStart = lower.indexOf(parent)
+                if (parentStart < 0) continue
+                val parentClose = lower.indexOf(parent.replace("<", "</"), parentStart)
+                val section = if (parentClose >= 0) gpxContent.substring(parentStart, parentClose) else gpxContent.substring(parentStart)
+                val name = section.substringAfter("<name>", "").substringBefore("</name>", "").trim()
+                if (name.isNotEmpty()) return name.unescapeXml()
+            }
+            val fallback = gpxContent.substringAfter("<name>", "").substringBefore("</name>", "").trim()
+            return if (fallback.isNotEmpty()) fallback.unescapeXml() else "Imported Track"
+        }
+
         fun fromGPX(gpxContent: String): Track? {
             try {
-                val trackName = gpxContent
-                    .substringAfter("<name>", "")
-                    .substringBefore("</name>", "Imported Track")
-                    .trim()
+                val trackName = extractName(gpxContent)
+                val lower = gpxContent.lowercase()
 
-                val trackPoints = mutableListOf<TrackPoint>()
-
-                var searchFrom = 0
-                while (true) {
-                    val trkptStart = gpxContent.indexOf("<trkpt ", searchFrom)
-                    if (trkptStart < 0) break
-                    val trkptEnd = gpxContent.indexOf("</trkpt>", trkptStart)
-                    if (trkptEnd < 0) break
-                    searchFrom = trkptEnd + 8
-
-                    val tag = gpxContent.substring(trkptStart, trkptEnd)
-                    val lat = tag.substringAfter("lat=\"", "").substringBefore("\"", "").toDoubleOrNull() ?: continue
-                    val lon = tag.substringAfter("lon=\"", "").substringBefore("\"", "").toDoubleOrNull() ?: continue
-
-                    val ele = tag.substringAfter("<ele>", "").substringBefore("</ele>", "").toDoubleOrNull()
-                    val timeStr = tag.substringAfter("<time>", "").substringBefore("</time>", "")
-                    val timestamp = try {
-                        Instant.parse(timeStr).toEpochMilliseconds()
-                    } catch (_: Exception) {
-                        currentTimeMillis()
-                    }
-
-                    trackPoints.add(
-                        TrackPoint(
-                            latLng = LatLng(lat, lon),
-                            timestamp = timestamp,
-                            altitude = ele,
-                            accuracy = null
-                        )
-                    )
+                // Use first non-empty type by priority: trkpt > rtept > wpt
+                var trackPoints = mutableListOf<TrackPoint>()
+                for (tagName in pointTagNames) {
+                    parsePointsFromTag(gpxContent, lower, tagName, trackPoints)
+                    if (trackPoints.isNotEmpty()) break
                 }
 
                 if (trackPoints.isEmpty()) return null
 
-                val startTime = trackPoints.minOfOrNull { it.timestamp } ?: currentTimeMillis()
-                val endTime = trackPoints.maxOfOrNull { it.timestamp } ?: currentTimeMillis()
+                // Replace 0L fallback timestamps with the earliest real timestamp
+                val realTimestamps = trackPoints.filter { it.timestamp > 0L }
+                if (realTimestamps.isNotEmpty()) {
+                    val fallback = realTimestamps.minOf { it.timestamp }
+                    trackPoints = trackPoints.map {
+                        if (it.timestamp == 0L) it.copy(timestamp = fallback) else it
+                    }.toMutableList()
+                } else {
+                    val now = currentTimeMillis()
+                    trackPoints = trackPoints.map { it.copy(timestamp = now) }.toMutableList()
+                }
+
+                val startTime = trackPoints.minOf { it.timestamp }
+                val endTime = trackPoints.maxOf { it.timestamp }
 
                 return Track(
                     name = trackName,
@@ -149,4 +209,18 @@ $trackPointsXml
         }
     }
 }
+
+private fun String.escapeXml(): String = this
+    .replace("&", "&amp;")
+    .replace("<", "&lt;")
+    .replace(">", "&gt;")
+    .replace("\"", "&quot;")
+    .replace("'", "&apos;")
+
+private fun String.unescapeXml(): String = this
+    .replace("&lt;", "<")
+    .replace("&gt;", ">")
+    .replace("&quot;", "\"")
+    .replace("&apos;", "'")
+    .replace("&amp;", "&")
 


### PR DESCRIPTION
GPX parser now handles wpt, rtept, and trkpt elements with priority (trkpt > rtept > wpt) to avoid mixing semantically different point types. Also adds self-closing tag support, single-quoted attributes, case-insensitive tag matching, coordinate validation, XML entity encoding/decoding in track names, and smarter timestamp fallback.

Opening a GPX file now shows a confirmation dialog with the filename instead of silently importing, and displays an error dialog on failure.